### PR TITLE
Bugfix: Fix localized API data parsing

### DIFF
--- a/exchanges/coindesk.py
+++ b/exchanges/coindesk.py
@@ -1,6 +1,11 @@
 from decimal import Decimal
+import locale
 
 from exchanges.helpers import get_datetime, get_response
+
+
+API_LOCALE = 'en_US.UTF-8'
+locale.setlocale(locale.LC_ALL, API_LOCALE)
 
 
 class CoinDesk(object):
@@ -12,13 +17,13 @@ class CoinDesk(object):
         )
         data = get_response(url)
         price = data['bpi'][currency]['rate']
-        return Decimal(price)
+        return cls._todec(price)
 
     @classmethod
     def get_past_price(cls, date):
         data = cls._get_historical_data(date)
         price = data['bpi'][date]
-        return Decimal(str(price))
+        return cls._todec(str(price))
 
     @classmethod
     def get_historical_data_as_dict(cls, start='2013-09-01', end=None):
@@ -52,3 +57,7 @@ class CoinDesk(object):
             )
         )
         return get_response(url)
+
+    @classmethod
+    def _todec(cls, value):
+        return Decimal(format(locale.atof(value), '.4f'))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,44 @@
+import unittest
+from decimal import Decimal
+
+
+from exchanges.coindesk import CoinDesk
+
+
+class CoinDeskDecimalConverstion(unittest.TestCase):
+    def setUp(self):
+        self.x = CoinDesk()
+
+    def test_current_price(self):
+        price = self.x.get_current_price()
+        self.assertEqual(
+            type(price),
+            Decimal
+        )
+
+    def test_past_price(self):
+        price = self.x.get_past_price('2017-01-01')
+        self.assertEqual(
+            type(price),
+            Decimal
+        )
+
+    def test_historical_data_as_dict(self):
+        prices = self.x.get_historical_data_as_dict(start='2017-01-01', end='2017-01-03')
+        for price in prices.values():
+            self.assertEqual(
+                type(price),
+                Decimal
+            )
+
+    def test_historical_data_as_list(self):
+        prices = self.x.get_historical_data_as_list(start='2017-01-01', end='2017-01-03')
+        for price in prices:
+            self.assertEqual(
+                type(price['price']),
+                Decimal
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
CoinDesk encodes prices according to the en_US locale.